### PR TITLE
Fix: generate correct AWS SIGv4 signature for compressed requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Java-Client
 
+```
+export AWS_ACCESS_KEY_ID=
+export AWS_SECRET_ACCESS_KEY=
+export AWS_SESSION_TOKEN=
+
+mvn install
+mvn compile exec:java -Dexec.mainClass="RESTClientTest"
+
+```
+
 1. step to repro issue: https://github.com/opensearch-project/OpenSearch/issues/3640
 
 2. signing sigv4 for streams https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Java-Client
 
+To reproduce https://github.com/opensearch-project/OpenSearch/issues/3640:
+
+Create openSearch domain in (AWS) which support IAM based AuthN/AuthZ.
+
 ```
 export AWS_ACCESS_KEY_ID=
 export AWS_SECRET_ACCESS_KEY=
@@ -7,16 +11,6 @@ export AWS_SESSION_TOKEN=
 
 mvn install
 mvn compile exec:java -Dexec.mainClass="RESTClientTest"
-
 ```
 
-1. step to repro issue: https://github.com/opensearch-project/OpenSearch/issues/3640
-
-2. signing sigv4 for streams https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html
-
-3. for (a) with content-length replace rest-client ( patched jar https://github.com/jiten1551/Java-Client/tree/master/src/main/resources) jar in ~/.m2 repo of local workspace (jar contains fix that uses content length instead of transfer-encoding) and re-run the RestClientTest.java file
-4. for (b) with transfer-encoding use original rest-client jar that use transfer encoding when compression enabled.
-
-### NOTE: for both to have ```x-amz-decoded-content-length``` add this header edit https://github.com/jiten1551/Java-Client/blob/master/src/main/java/com/amazonaws/http/AWSRequestSigningApacheInterceptor.java#L181
-
-
+Toggle [`.setCompressionEnabled(true/false)`](https://github.com/dblock/Java-Client/blob/master/src/main/java/RESTClientTest.java#L103).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ To reproduce https://github.com/opensearch-project/OpenSearch/issues/3640:
 
 Create openSearch domain in (AWS) which support IAM based AuthN/AuthZ.
 
+Update the value of `host` and `region` in [RESTClientTest.java](/src/main/java/RESTClientTest.java#L27) to your endpoint.
+
 ```
 export AWS_ACCESS_KEY_ID=
 export AWS_SECRET_ACCESS_KEY=
@@ -13,4 +15,12 @@ mvn install
 mvn compile exec:java -Dexec.mainClass="RESTClientTest"
 ```
 
-Toggle [`.setCompressionEnabled(true/false)`](https://github.com/dblock/Java-Client/blob/master/src/main/java/RESTClientTest.java#L103).
+Toggle [`.setCompressionEnabled(true/false)`](src/main/java/RESTClientTest.java#L103).
+
+With compression disabled the code will create an index, add a document, then cleanup.
+
+With compression enabled the request will fail with a 403 forbidden and an invalid signature error.
+
+```
+{"message":"The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details."}
+```

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
-            <version>1.11.106</version>
+            <version>1.12.247</version>
         </dependency>
         <dependency>
             <groupId>org.opensearch.client</groupId>

--- a/src/main/java/RESTClientTest.java
+++ b/src/main/java/RESTClientTest.java
@@ -24,12 +24,9 @@ import java.util.HashMap;
 
 public class RESTClientTest {
 
-    private static String host = "https://xxxxxx"; // put your own end-point
+    private static String host = "https://search-dblock-test-opensearch-21-tu5gqrjd4vg4qazjsu6bps5zsy.us-west-2.es.amazonaws.com"; // put your own end-point
     private static String serviceName = "es";
-    private static String region = "eu-west-1";
-
-
-
+    private static String region = "us-west-2";
 
     public static void main(String[] args) throws IOException {
         RestHighLevelClient searchClient = searchClient(serviceName, region);

--- a/src/main/java/com/amazonaws/http/AWSRequestSigningApacheInterceptor.java
+++ b/src/main/java/com/amazonaws/http/AWSRequestSigningApacheInterceptor.java
@@ -125,7 +125,7 @@ public class AWSRequestSigningApacheInterceptor implements HttpRequestIntercepto
         headers.addAll(Arrays.asList(request.getAllHeaders()));
 
         if (contentLength > 0) {
-            headers.add(new BasicHeader("x-Amz-Decoded-Content-Length", String.valueOf(contentLength)));
+            headers.add(new BasicHeader("x-amz-decoded-content-length", Long.toString(contentLength)));
         }
 
         // headers.add(new BasicHeader("x-amz-content-sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD"));


### PR DESCRIPTION
1. Set `x-Amz-Decoded-Content-Length` to decompressed content.
2. Do not skip any headers.

If you can confirm let's figure out what this code should really be. For starters, I think decompressing initially uncompressed content is probably not very efficient, need to find a way to get that content length directly.